### PR TITLE
Upgrade SENAITE's Plone version to 4.3.17

### DIFF
--- a/senaite_configure.yml
+++ b/senaite_configure.yml
@@ -252,7 +252,7 @@ firewall_use_fail2ban: no
 
 
 ### SENAITE PLONE ###
-plone_version: '4.3.15'
+plone_version: '4.3.17'
 plone_initial_password: admin
 plone_instance_name: senaitelims
 plone_site_id: senaitelims


### PR DESCRIPTION
Related PR in `senaite.core`: https://github.com/senaite/senaite.core/pull/879

## Description of the issue/feature this PR addresses

Linked issue: #2 

## Current behavior before PR

The setup fails when trying to download `buildout-cache.tar.bz2` from http://dist.plone.org/release/4.3.15/ because the file cannot be found. The file does exist for previous and posterior Plone versions.

## Desired behavior after PR is merged

The setup finishes without errors and everything is setup properly.

**Note**: In the near future it may be worth to provide a custom built `buildout-cache.tar.bz2` on one of http://downloads.senaite.com as stated in the comments of #2.