### PR TITLE
Modify ansible ssh user in Vagrant hosts

### DIFF
--- a/vagrant_hosts.cfg
+++ b/vagrant_hosts.cfg
@@ -1,2 +1,2 @@
 [vagrant]
-senaite ansible_ssh_host=192.168.33.10 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=.vagrant/machines/app/virtualbox/private_key
+senaite ansible_ssh_host=192.168.33.10 ansible_ssh_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/app/virtualbox/private_key


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Running `$ ansible-playbook -i vagrant_hosts.cfg vagrant_playbook.yml` with the current `vagrant_hosts.cfg` file results in an error when trying to connect to the host: `Permission denied (publickey).` 

Relevant comment from @ramonski in https://gitter.im/senaite/Lobby (1st April 2018) who also faced the same issue.
> No issues with the provided version on GitHub, except that I had to change the ansible_ssh_user in vagrant_hosts.cfg from ubuntu to vagrant...

## Current behavior before PR

 `$ ansible-playbook -i vagrant_hosts.cfg vagrant_playbook.yml` fails with the error stated above.

## Desired behavior after PR is merged

 `$ ansible-playbook -i vagrant_hosts.cfg vagrant_playbook.yml` completes its execution without errors.