### PR TITLE
Changed to oefenweb.postfix role

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,7 @@ The Playbook is splitted into different tasks which need to be run in a specific
   - Installs MUNIN and copies over custom templates from the `templates` folder.
 
 - `senaite_postfix`
-  - Dependency Role: [tersmitten.postfix](https://galaxy.ansible.com/tersmitten/postfix)
+  - Dependency Role: [tersmitten.postfix](https://galaxy.ansible.com/oefenweb/postfix)
   - Installs Postfix and copies over custom templates from the `templates` folder.
 
 

--- a/senaite_postfix.yml
+++ b/senaite_postfix.yml
@@ -5,7 +5,7 @@
 
 - name: "Run POSTFIX Role"
   include_role:
-    name: tersmitten.postfix
+    name: oefenweb.postfix
 
 - name: update configuration file
   template:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the old references to `tersmitten.postfix` to `oefenweb.postfix`.
See: https://github.com/senaite/senaite.ansible-playbook/pull/7