### PR TITLE
Fix ImportError: The _imagingft C module is not installed

### DIFF
--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -17,3 +17,4 @@ apt_packages:
     - libgdk-pixbuf2.0-0
     - ssl-cert
     - acl
+    - libfreetype6-dev


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Although not a dependency of senaite, [`python-barcode` library](https://pypi.org/project/python-barcode/) is commonly used, but it fails if `libfreetype6-dev` is not installed, cause Pillow gets compiled without libfreetype during buildout.

The following is the traceback for further reference.

```
  Module barcode.base, line 82, in write
  Module barcode.codex, line 106, in render
  Module barcode.base, line 103, in render
  Module barcode.writer, line 188, in render
  Module barcode.writer, line 280, in _paint_text
  Module PIL.ImageFont, line 239, in truetype
  Module PIL.ImageFont, line 128, in __init__
  Module PIL.ImageFont, line 37, in __getattr__
ImportError: The _imagingft C module is not installed
```

Note that if `libfreetype6-dev` is installed, in PIL summary during buildout, the following must appear:

```
--------------------------------------------------------------------
PIL SETUP SUMMARY
--------------------------------------------------------------------
version      Pillow 3.3.0
platform     linux2 2.7.12 (default, Dec  4 2017, 14:50:18)
             [GCC 5.4.0 20160609]
--------------------------------------------------------------------
--- JPEG support available
*** OPENJPEG (JPEG2000) support not available
--- ZLIB (PNG/ZIP) support available
*** LIBIMAGEQUANT support not available
*** LIBTIFF support not available
--- FREETYPE2 support available
*** LITTLECMS2 support not available
*** WEBP support not available
*** WEBPMUX support not available
--------------------------------------------------------------------
To add a missing option, make sure you have the required
library and headers.
See https://pillow.readthedocs.io/en/latest/installation.html#building-from-source
```

## Current behavior before PR

Traceback when using `python-barcode` library to generate barcodes with python.

## Desired behavior after PR is merged

No Traceback. The barcode is generated without problems.
