### PR TITLE
Fix HAProxy Version task for versions > 1.8

### DIFF
--- a/senaite_haproxy.yml
+++ b/senaite_haproxy.yml
@@ -7,7 +7,7 @@
     name: geerlingguy.haproxy
 
 - name: SHELL | Get HAPROXY Version
-  shell: haproxy -v | grep -o "[0-9]\.[0-9]"
+  shell: haproxy -v | grep -o "[0-9]\.[0-9]" | head -1
   register: haproxy_version
   tags:
     - senaite-haproxy-version


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the HAProxy version extraction for Ubuntu 18.04

## Current behavior before PR

Version < 1.6 was assumed and the wrong config used

## Desired behavior after PR is merged

Version > 1.6 is assumed and the right config used
